### PR TITLE
Converted BoundsOctreeNode.GetBounds() and BoundsOctree.GetMaxBounds(…

### DIFF
--- a/Scripts/BoundsOctree.cs
+++ b/Scripts/BoundsOctree.cs
@@ -25,6 +25,9 @@ public class BoundsOctree<T> {
 	// The total amount of objects currently in the tree
 	public int Count { get; private set; }
 
+	// Gets the bounding box that contains the whole octree
+	public Bounds MaxBounds { get { return rootNode.Bounds; } }
+
 	// Root node of the octree
 	BoundsOctreeNode<T> rootNode;
 
@@ -172,10 +175,6 @@ public class BoundsOctree<T> {
 		//AddCollisionCheck(checkRay);
 		//#endif
 		rootNode.GetColliding(ref checkRay, collidingWith, maxDistance);
-	}
-
-	public Bounds GetMaxBounds() {
-		return rootNode.GetBounds();
 	}
 
 	/// <summary>

--- a/Scripts/BoundsOctreeNode.cs
+++ b/Scripts/BoundsOctreeNode.cs
@@ -9,6 +9,9 @@ public class BoundsOctreeNode<T> {
 
 	// Length of this node if it has a looseness of 1.0
 	public float BaseLength { get; private set; }
+	
+	// Gets the bounding box that contains this node
+	public Bounds Bounds { get { return bounds; } }
 
 	// Looseness value for this node
 	float looseness;
@@ -242,10 +245,6 @@ public class BoundsOctreeNode<T> {
 		}
 
 		children = childOctrees;
-	}
-
-	public Bounds GetBounds() {
-		return bounds;
 	}
 
 	/// <summary>

--- a/Scripts/PointOctree.cs
+++ b/Scripts/PointOctree.cs
@@ -18,6 +18,15 @@ public class PointOctree<T> where T : class {
 	// The total amount of objects currently in the tree
 	public int Count { get; private set; }
 
+	// Gets the bounding box that contains the whole octree
+	public Bounds MaxBounds {
+		get {
+			return new Bounds(
+				rootNode.Center, 
+				new Vector3(rootNode.SideLength, rootNode.SideLength, rootNode.SideLength));
+		}
+	}
+
 	// Root node of the octree
 	PointOctreeNode<T> rootNode;
 


### PR DESCRIPTION
…) methods to properties (respectively Bounds and MaxBounds) to compile with Microsoft's Design Guidelines for Property Usage.

Added PointOctree.MaxBounds property.